### PR TITLE
Update TaskLoaderNotifier.cs

### DIFF
--- a/Sharpnado.TaskLoaderView/TaskLoaderNotifier.cs
+++ b/Sharpnado.TaskLoaderView/TaskLoaderNotifier.cs
@@ -56,7 +56,6 @@ namespace Sharpnado.TaskLoaderView
                 {
                     InternalLogger.Warn("A loading task is currently running: discarding previous call");
                     OnTaskOverloaded();
-                    return;
                 }
 
                 _loadingTaskSource = loadingTaskSource;


### PR DESCRIPTION
Continue task after discarding the previous call as in TaskLoaderNotifier<TData>.
With the return the second call to load does not execute correctly.